### PR TITLE
Build Stoney on stable tarballs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -53,6 +53,7 @@ function build_kernel {
         rm linux-${stoney_ver}.tar.xz
         mv linux-${stoney_ver} $kernel_source_dir
         cd $kernel_source_dir
+        patch -p1 < ../patches/stoney/*
     else
         if [[ ! -d $kernel_source_dir ]]; then
             git clone $kernel_source_url $kernel_source_dir

--- a/build.sh
+++ b/build.sh
@@ -55,6 +55,9 @@ function build_kernel {
         cd $kernel_source_dir
         patch -p1 < ../patches/stoney/*
     else
+        if [[ ! -d ${kernel_source_dir}/.git ]]; then
+            rm -rf $kernel_source_dir
+        fi
         if [[ ! -d $kernel_source_dir ]]; then
             git clone $kernel_source_url $kernel_source_dir
         fi

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ function build_kernel {
     variant=$1
     case $variant in
         stoney)
-            branch=master
+      stoney_ver=6.4.6
 	    arch=x86_64
 
 	    # Install amdgpu firmware
@@ -44,12 +44,23 @@ function build_kernel {
 
     echo "Building $variant kernel"
 
-    if [[ ! -d $kernel_source_dir ]]; then
-        git clone $kernel_source_url $kernel_source_dir
+    if [[ $variant == 'stoney' ]]; then
+        if [[ -d $kernel_source_dir ]]; then
+            rm -rf $kernel_source_dir
+        fi
+        curl -LO https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${stoney_ver}.tar.xz
+        tar xf linux-${stoney_ver}.tar.xz
+        rm linux-${stoney_ver}.tar.xz
+        mv linux-${stoney_ver} $kernel_source_dir
+        cd $kernel_source_dir
+    else
+        if [[ ! -d $kernel_source_dir ]]; then
+            git clone $kernel_source_url $kernel_source_dir
+        fi
+        cd $kernel_source_dir
+        git switch $branch
     fi
-    cd $kernel_source_dir
-    git switch $branch
-
+    
     # make sure source is clean from any previous builds
     make clean
 

--- a/patches/stoney/emmc.patch
+++ b/patches/stoney/emmc.patch
@@ -1,0 +1,114 @@
+diff --git a/drivers/mmc/host/sdhci-pci-o2micro.c b/drivers/mmc/host/sdhci-pci-o2micro.c
+index 620f52ad9667..28847aa1eaef 100644
+--- a/drivers/mmc/host/sdhci-pci-o2micro.c
++++ b/drivers/mmc/host/sdhci-pci-o2micro.c
+@@ -12,7 +12,6 @@
+ #include <linux/mmc/mmc.h>
+ #include <linux/delay.h>
+ #include <linux/iopoll.h>
+-#include <linux/bitfield.h>
+ 
+ #include "sdhci.h"
+ #include "sdhci-pci.h"
+@@ -45,16 +44,12 @@
+ #define O2_SD_CAP_REG0		0x334
+ #define O2_SD_UHS1_CAP_SETTING	0x33C
+ #define O2_SD_DELAY_CTRL	0x350
+-#define O2_SD_OUTPUT_CLK_SOURCE_SWITCH	0x354
+ #define O2_SD_UHS2_L1_CTRL	0x35C
+ #define O2_SD_FUNC_REG3		0x3E0
+ #define O2_SD_FUNC_REG4		0x3E4
+ #define O2_SD_LED_ENABLE	BIT(6)
+ #define O2_SD_FREG0_LEDOFF	BIT(13)
+-#define O2_SD_SEL_DLL		BIT(16)
+ #define O2_SD_FREG4_ENABLE_CLK_SET	BIT(22)
+-#define O2_SD_PHASE_MASK	GENMASK(23, 20)
+-#define O2_SD_FIX_PHASE		FIELD_PREP(O2_SD_PHASE_MASK, 0x9)
+ 
+ #define O2_SD_VENDOR_SETTING	0x110
+ #define O2_SD_VENDOR_SETTING2	0x1C8
+@@ -309,13 +304,9 @@ static int sdhci_o2_dll_recovery(struct sdhci_host *host)
+ static int sdhci_o2_execute_tuning(struct mmc_host *mmc, u32 opcode)
+ {
+ 	struct sdhci_host *host = mmc_priv(mmc);
+-	struct sdhci_pci_slot *slot = sdhci_priv(host);
+-	struct sdhci_pci_chip *chip = slot->chip;
+ 	int current_bus_width = 0;
+ 	u32 scratch32 = 0;
+ 	u16 scratch = 0;
+-	u8  scratch_8 = 0;
+-	u32 reg_val;
+ 
+ 	/*
+ 	 * This handler implements the hardware tuning that is specific to
+@@ -334,34 +325,6 @@ static int sdhci_o2_execute_tuning(struct mmc_host *mmc, u32 opcode)
+ 	scratch |= O2_SD_PWR_FORCE_L0;
+ 	sdhci_writew(host, scratch, O2_SD_MISC_CTRL);
+ 
+-	/* Stop clk */
+-	reg_val = sdhci_readw(host, SDHCI_CLOCK_CONTROL);
+-	reg_val &= ~SDHCI_CLOCK_CARD_EN;
+-	sdhci_writew(host, reg_val, SDHCI_CLOCK_CONTROL);
+-
+-	if ((host->timing == MMC_TIMING_MMC_HS200) ||
+-		(host->timing == MMC_TIMING_UHS_SDR104)) {
+-		/* UnLock WP */
+-		pci_read_config_byte(chip->pdev, O2_SD_LOCK_WP, &scratch_8);
+-		scratch_8 &= 0x7f;
+-		pci_write_config_byte(chip->pdev, O2_SD_LOCK_WP, scratch_8);
+-
+-		/* Set pcr 0x354[16] to choose dll clock, and set the default phase */
+-		pci_read_config_dword(chip->pdev, O2_SD_OUTPUT_CLK_SOURCE_SWITCH, &reg_val);
+-		reg_val &= ~(O2_SD_SEL_DLL | O2_SD_PHASE_MASK);
+-		reg_val |= (O2_SD_SEL_DLL | O2_SD_FIX_PHASE);
+-		pci_write_config_dword(chip->pdev, O2_SD_OUTPUT_CLK_SOURCE_SWITCH, reg_val);
+-
+-		/* Lock WP */
+-		pci_read_config_byte(chip->pdev, O2_SD_LOCK_WP, &scratch_8);
+-		scratch_8 |= 0x80;
+-		pci_write_config_byte(chip->pdev, O2_SD_LOCK_WP, scratch_8);
+-	}
+-	/* Start clk */
+-	reg_val = sdhci_readw(host, SDHCI_CLOCK_CONTROL);
+-	reg_val |= SDHCI_CLOCK_CARD_EN;
+-	sdhci_writew(host, reg_val, SDHCI_CLOCK_CONTROL);
+-
+ 	/* wait DLL lock, timeout value 5ms */
+ 	if (readx_poll_timeout(sdhci_o2_pll_dll_wdt_control, host,
+ 		scratch32, (scratch32 & O2_DLL_LOCK_STATUS), 1, 5000))
+@@ -561,7 +524,6 @@ static void sdhci_o2_enable_clk(struct sdhci_host *host, u16 clk)
+ static void sdhci_pci_o2_set_clock(struct sdhci_host *host, unsigned int clock)
+ {
+ 	u16 clk;
+-	u8 scratch;
+ 	u32 scratch_32;
+ 	struct sdhci_pci_slot *slot = sdhci_priv(host);
+ 	struct sdhci_pci_chip *chip = slot->chip;
+@@ -573,11 +535,6 @@ static void sdhci_pci_o2_set_clock(struct sdhci_host *host, unsigned int clock)
+ 	if (clock == 0)
+ 		return;
+ 
+-	/* UnLock WP */
+-	pci_read_config_byte(chip->pdev, O2_SD_LOCK_WP, &scratch);
+-	scratch &= 0x7f;
+-	pci_write_config_byte(chip->pdev, O2_SD_LOCK_WP, scratch);
+-
+ 	if ((host->timing == MMC_TIMING_UHS_SDR104) && (clock == 200000000)) {
+ 		pci_read_config_dword(chip->pdev, O2_SD_PLL_SETTING, &scratch_32);
+ 
+@@ -590,15 +547,6 @@ static void sdhci_pci_o2_set_clock(struct sdhci_host *host, unsigned int clock)
+ 			o2_pci_set_baseclk(chip, 0x25100000);
+ 	}
+ 
+-	pci_read_config_dword(chip->pdev, O2_SD_OUTPUT_CLK_SOURCE_SWITCH, &scratch_32);
+-	scratch_32 &= ~(O2_SD_SEL_DLL | O2_SD_PHASE_MASK);
+-	pci_write_config_dword(chip->pdev, O2_SD_OUTPUT_CLK_SOURCE_SWITCH, scratch_32);
+-
+-	/* Lock WP */
+-	pci_read_config_byte(chip->pdev, O2_SD_LOCK_WP, &scratch);
+-	scratch |= 0x80;
+-	pci_write_config_byte(chip->pdev, O2_SD_LOCK_WP, scratch);
+-
+ 	clk = sdhci_calc_clk(host, clock, &host->mmc->actual_clock);
+ 	sdhci_o2_enable_clk(host, clk);
+ }


### PR DESCRIPTION
Since Stoney requires little patches and is currently being built on top of mainline within the kernel fork, it would be a better option to use stable kernel tarballs. This should also allow for UCM2 audio to work, which is broken on 6.5-rc1.